### PR TITLE
Allows MySQL unix socket connections

### DIFF
--- a/includes/Db.php
+++ b/includes/Db.php
@@ -72,7 +72,14 @@ class Db extends ORM
 		{
 			if ($dbType === 'mysql')
 			{
-				self::configure('connection_string', 'mysql:host=' . $dbHost . ';dbname=' . $dbName . ';charset=utf8');
+				if (strlen($dbHost) > 0 && $dbHost[0] == '/')
+				{
+					self::configure('connection_string', 'mysql:unix_socket=' . $dbHost . ';dbname=' . $dbName . ';charset=utf8');
+				}
+				else
+				{
+					self::configure('connection_string', 'mysql:host=' . $dbHost . ';dbname=' . $dbName . ';charset=utf8');
+				}
 			}
 			else
 			{


### PR DESCRIPTION
Fixes #305. 

Checking the first character '/' - if this is the case, it's probably a path (and not a hostname / port). If this is not the case (or if $dbHost is empty), we go back to the original behavior.